### PR TITLE
Fix error parsing for newer versions of Rust

### DIFF
--- a/src/suite/failure.rs
+++ b/src/suite/failure.rs
@@ -1,8 +1,6 @@
 use std::str;
 use nom::line_ending;
 
-use utility_parsers::rest_of_line;
-
 #[derive(Debug, PartialEq)]
 pub struct Failure<'a, 'b> {
     pub name: &'a str,
@@ -27,7 +25,7 @@ named!(
     failure<Failure>,
     do_parse!(
         name: fail_line >>
-        error: rest_of_line >>
+        error: map_res!(take_until!("\n\n"), str::from_utf8) >>
         opt!(
             tag!("note: Run with `RUST_BACKTRACE=1` for a backtrace.")
         ) >>


### PR DESCRIPTION
Newer versions of rust and cargo have changed the way they output
test results and the error parsing is broken. This commit addresses
this issue by changing the way errors are parsed. The new way
splits errors by a double new line (\n\n)